### PR TITLE
GitHub CLIで別リポジトリのlabelをcloneする

### DIFF
--- a/articles/ff5aaa4241cd24.md
+++ b/articles/ff5aaa4241cd24.md
@@ -1,0 +1,99 @@
+---
+title: "GitHub CLIで別リポジトリのlabelをcloneする"
+emoji: "⌨"
+type: "tech" # tech: 技術記事 / idea: アイデア
+topics: [github, cli, issue]
+published: true
+---
+
+先日GitHubのIssueを別リポジトリへ移行する機会があったが、isseueに紐づくlabelが継承されていなかったため、移行元のリポジトリからcloneすることにした。
+
+# GitHub CLIのインストール
+
+labelのcloneはGitHub CLIを使って行う。
+
+https://github.com/cli/cli
+
+ドキュメント記載のコマンドでGitHub CLIをインストールする。
+
+```
+% brew install gh
+```
+
+アップデートが必要な際は以下コマンドを実行。
+
+```
+% brew upgrade gh
+```
+
+# GitHubアカウントの認証
+GitHub CLIインストール後、GitHubアカウントの認証を行う。
+https://cli.github.com/manual/gh_auth_login
+
+
+以下コマンドで認証フロー開始。
+```
+% gh auth login
+```
+
+認証に必要な質問に答えていく。
+```
+? What account do you want to log into? GitHub.com
+? What is your preferred protocol for Git operations? HTTPS
+? Authenticate Git with your GitHub credentials? Yes
+? How would you like to authenticate GitHub CLI? Login with a web browser
+```
+
+最後にワンタイムコードが発行されるので、ブラウザで開かれたGitHubの画面にコピペする
+
+```
+! First copy your one-time code: xxxx-xxxx
+Press Enter to open github.com in your browser... 
+✓ Authentication complete.
+- gh config set -h github.com git_protocol https
+✓ Configured git protocol
+✓ Logged in as unsolublesugar
+```
+無事に認証完了すればGitHub CLIコマンドが使えるようになる。
+![](https://storage.googleapis.com/zenn-user-upload/9ffa8519dcf2-20230707.png)
+
+使えるコマンドやオプションの詳細はマニュアルを参照。
+https://cli.github.com/manual/
+
+# gh labelでlabelをcloneする
+
+label関連の操作は `gh label` コマンドを使う。
+
+- gh label clone
+- gh label create
+- gh label delete
+- gh label edit
+- gh label list
+
+例えばGitHubリポジトリのlabel一覧取得とかできる。もちろん作成、削除、編集も可能。
+```
+% gh label list -R OWNER/REPO
+
+Showing 10 of 10 labels in OWNER/REPO
+
+bug               Something isn't working                     #d73a4a
+documentation     Improvements or additions to documentation  #0075ca
+duplicate         This issue or pull request already exists   #cfd3d7
+enhancement       New feature or request                      #a2eeef
+good first issue  Good for newcomers                          #7057ff
+help wanted       Extra attention is needed                   #008672
+invalid           This doesn't seem right                     #e4e669
+question          Further information is requested            #d876e3
+wontfix           This will not be worked on                  #ffffff
+refactor-devops   refactoring or DevOps-related               #82D694
+```
+
+`REPO-A`のlabelを別リポジトリ `REPO-B` にクローンする場合は、以下コマンドを叩けばOK。
+```
+ % gh label clone OWNER/REPO-A -R OWNER/REPO-B
+✓ Cloned 10 labels from OWNER/REPO-A to OWNER/REPO-B
+```
+
+事前にlabelをCloneしておけば、isseue移行時も同一名称のlabelが存在していればそのまま継承される。すでに運用中のリポジトリでlabelを整えている場合 `gh clone` で移植するのが良さそう。
+
+https://zenn.dev/unsoluble_sugar/articles/930c056d301dea


### PR DESCRIPTION
GitHub CLIで別リポジトリのlabelをcloneする方法について。
インストール手順とcloneの仕方を説明。
<img width="757" alt="スクリーンショット_2023-07-21_141840" src="https://github.com/unsolublesugar/zenn-content/assets/8685879/af32d4c9-1a44-402b-8f10-8f25f1682719">
<img width="744" alt="スクリーンショット_2023-07-21_141847" src="https://github.com/unsolublesugar/zenn-content/assets/8685879/2020527a-c150-4081-9087-8984edb0191d">
