### PR TITLE
記事サムネ用の絵文字変更

### DIFF
--- a/articles/ff5aaa4241cd24.md
+++ b/articles/ff5aaa4241cd24.md
@@ -1,6 +1,6 @@
 ---
 title: "GitHub CLIで別リポジトリのlabelをcloneする"
-emoji: "⌨"
+emoji: "⌨️"
 type: "tech" # tech: 技術記事 / idea: アイデア
 topics: [github, cli, issue]
 published: true


### PR DESCRIPTION
キーボードの絵文字が想定と異なるものだったため差し替え
<img width="111" alt="スクリーンショット_2023-07-21_142339" src="https://github.com/unsolublesugar/zenn-content/assets/8685879/5649758e-fd08-4958-9d3d-e6d0369f1976">
