### PR TITLE
記事サムネ用の絵文字をラベルに差し替え。

### DIFF
--- a/articles/ff5aaa4241cd24.md
+++ b/articles/ff5aaa4241cd24.md
@@ -1,6 +1,6 @@
 ---
 title: "GitHub CLIで別リポジトリのlabelをcloneする"
-emoji: "⌨️"
+emoji: "🏷"
 type: "tech" # tech: 技術記事 / idea: アイデア
 topics: [github, cli, issue]
 published: true


### PR DESCRIPTION
CLIの説明でキーボードにしていたが本来伝えたいことはラベルの話だったため
<img width="99" alt="スクリーンショット_2023-07-21_142634" src="https://github.com/unsolublesugar/zenn-content/assets/8685879/4d7e33ee-8ddd-41ae-b320-1cc6026dbe15">
