### PR TITLE
labelのclone解説記事リンクを追加

### DIFF
--- a/articles/930c056d301dea.md
+++ b/articles/930c056d301dea.md
@@ -36,3 +36,6 @@ https://docs.github.com/ja/issues/tracking-your-work-with-issues/transferring-an
 ![](https://storage.googleapis.com/zenn-user-upload/53906f4d0f23-20230705.png)
 
 誤って別のリポジトリにissueを立ててしまった場合にも使えますね。
+
+**追記：本記事と関連するlabelのclone方法について書きました**
+https://zenn.dev/unsoluble_sugar/articles/ff5aaa4241cd24


### PR DESCRIPTION
[issueの移行記事](https://zenn.dev/unsoluble_sugar/articles/930c056d301dea)にlabelのclone解説記事リンクを追加。

<img width="752" alt="スクリーンショット_2023-07-21_143024" src="https://github.com/unsolublesugar/zenn-content/assets/8685879/a933c190-8fa9-4eca-9a01-e5cf79d3cc3a">
