### PR TITLE
Built-in workflowsで新規作成issueをGithub Projectsへ自動追加する

### DIFF
--- a/articles/75e65267907956.md
+++ b/articles/75e65267907956.md
@@ -1,0 +1,62 @@
+---
+title: "Built-in workflowsで新規作成issueをGithub Projectsへ自動追加する"
+emoji: "🔧"
+type: "tech" # tech: 技術記事 / idea: アイデア
+topics: [github, issue]
+published: true
+---
+
+開発のタスク管理に[Github Projects](https://docs.github.com/en/issues/planning-and-tracking-with-projects/learning-about-projects/about-projects)を利用しているのですが、issueの作成時にProjectへの追加とstatus選択をポチポチ行うのが煩雑だったため自動化することにしました。
+
+![](https://storage.googleapis.com/zenn-user-upload/3f90401c442f-20230807.jpg)
+
+Github ProjectsにはBuilt-in workflowsという機能が用意されており、この手の簡易なワークフローはGUI上でサクッと自動化することができます。
+https://docs.github.com/en/issues/planning-and-tracking-with-projects/automating-your-project/using-the-built-in-automations
+
+# isseu作成時にProjectへ自動追加する
+対象のGitHub Projectを開き、画面右上の三点メニュー内にある「Workflows」を選択します。
+![](https://storage.googleapis.com/zenn-user-upload/019331570ddb-20230807.jpg)
+
+サイドバーのDefault Workflowsから「Auto-add to project」を選択し、Editボタンをクリック。
+![](https://storage.googleapis.com/zenn-user-upload/069ecde6a4f4-20230807.jpg)
+
+リポジトリを選択し、対象とするissueのフィルタリング設定を行います。
+![](https://storage.googleapis.com/zenn-user-upload/1b1702979040-20230807.jpg)
+
+`See [n] existing items that match　this query` のリンクをクリックすると、該当するissueの一覧が確認できます。
+![](https://storage.googleapis.com/zenn-user-upload/d734839dccb4-20230807.jpg)
+
+既存issueについては、リンク先の画面からProjectsに一括追加することができます。
+
+> Going forward, all new or updated items that match your filter will be auto added. You can also manually add items that currently match your filter
+> [Adding items to your project - GitHub Docs](https://docs.github.com/en/issues/planning-and-tracking-with-projects/managing-items-in-your-project/adding-items-to-your-project#adding-multiple-issues-or-pull-requests-from-a-repository)
+
+![](https://storage.googleapis.com/zenn-user-upload/1690367e580e-20230807.jpg)
+
+対象issueの条件を定めたら「Save and turn on workflow」ボタンをクリックして適用。Auto-add to projectのスイッチがOnの状態になっていれば有効化されています。
+![](https://storage.googleapis.com/zenn-user-upload/10fae313b8de-20230807.png)
+
+新規のissueを作成をして、Projectに自動追加されることを確認しましょう。
+
+# Project追加時にstatusを自動でセットする
+Projectへの自動追加と合わせて、statusもデフォルトで設定されるようにします。
+サイドメニューから「Item added to Project」を選択し、先ほどと同様にEditボタンをクリック。
+![](https://storage.googleapis.com/zenn-user-upload/401f853a23c0-20230807.png)
+
+`When an item is added to the project` 項目で、issueとPull Requestの選択が可能です。
+
+![](https://storage.googleapis.com/zenn-user-upload/4fa6b1d7ef6c-20230807.png)
+
+`Set value` 項目でセットするstatusを選択。
+![](https://storage.googleapis.com/zenn-user-upload/d71c8a42e471-20230807.png)
+
+「Save and turn on workflow」ボタンクリックで適用完了です。
+![](https://storage.googleapis.com/zenn-user-upload/752468101c8c-20230807.png)
+
+他にも、一定日数を超えたissueをアーカイブさせるワークフローなどがGUI上で設定できます。
+![](https://storage.googleapis.com/zenn-user-upload/0889198d3665-20230807.png)
+
+# 開発ワークフロー構築はGitHub Actionsで
+さらに詳細なカスタマイズを行いたい場合は、[GitHub GraphQL API](https://docs.github.com/en/graphql)と[GitHub Actions](https://docs.github.com/en/actions)を用いたワークフロー構築が可能です。CI/CD絡めたジョブ実行などはこちらを活用すると良いでしょう。
+https://docs.github.com/en/issues/planning-and-tracking-with-projects/automating-your-project/using-the-api-to-manage-projects
+https://docs.github.com/en/issues/planning-and-tracking-with-projects/automating-your-project/automating-projects-using-actions


### PR DESCRIPTION
Built-in workflowsを用いて、新規作成issueをGithub Projectsへ自動追加する方法を解説。
![スクリーンショット_2023-08-07_172351](https://github.com/unsolublesugar/zenn-content/assets/8685879/fb1bdf2e-1e80-47de-8126-2712dc0dde6d)
