### PR TITLE
Windows環境でnpm-scripts実行に使用するシェルを変更する

### DIFF
--- a/articles/96c3e32ac4e723.md
+++ b/articles/96c3e32ac4e723.md
@@ -1,0 +1,79 @@
+---
+title: "Windows環境でnpm-scripts実行に使用するシェルを変更する"
+emoji: "🦪"
+type: "tech" # tech: 技術記事 / idea: アイデア
+topics: [nextjs, npm, shell, bash]
+published: true
+---
+
+# npm run実行時の構文エラー
+普段Mac環境で開発しているNext.jsプロジェクトをWindows環境で動かそうとしたところ、`npm run dev` 実行時に構文エラーが発生した。
+```
+'PORT' は、内部コマンドまたは外部コマンド、
+操作可能なプログラムまたはバッチ ファイルとして認識されていません。
+```
+
+コマンドはgit-bash上で実行しており、該当箇所のpackage.jsonでは以下のようなポート番号を指定する環境変数を記述している。
+```json
+"scripts": {
+    "dev": "PORT=15000 NODE_OPTIONS='--inspect' next dev",
+```
+
+# 原因
+
+どうやらWindows環境ではnpm-scripts実行時、cmd（コマンド プロンプト）を使用する形となっているため、UNIX系の記述方式では構文エラーが出る模様。
+
+```shell
+$ npm config get shell
+C:\Windows\system32\cmd.exe
+
+$ npm config get script-shell
+null
+```
+
+調べてみると、npm-scriptsが実行されるシェルはプラットフォームに依存することが判明した。
+> The actual shell your script is run within is platform dependent. By default, on Unix-like systems it is the /bin/sh command, on Windows it is cmd.exe. The actual shell referred to by /bin/sh also depends on the system. You can customize the shell with the script-shell config.
+> [npm-run-script | npm Docs ](https://docs.npmjs.com/cli/v9/commands/npm-run-script)
+
+# 検証
+
+`package.json` の環境変数の設定記述（構文エラーになっている箇所）をcmdが解釈できるよう書き換えてみる。
+```json
+ "dev": "PORT=15000 NODE_OPTIONS='--inspect' next dev",
+```
+↓
+```json
+"dev": "set PORT=15000 NODE_OPTIONS=--inspect && next dev",
+```
+
+確かにこれで `npm run dev` 実行時に構文エラーが出なくなり、プロジェクトが正常起動できた。
+
+# npm-scriptsの実行シェルをgit-bashに変更する
+前述の記述変更でも構文エラーは解消できるが、普段git-bash上でコマンド操作を行っているため、npm-scripts実行時に使用されるdefaultシェルもgit-bashに合わせることにした。
+
+`npm config set`の `script-shell` で使用するシェルの指定可能。
+
+> script-shell
+> - Default: null
+> - Type: path
+>
+> The shell to use for scripts run with the npm run command.
+> [script-shell - npm Documentation](https://doc.codingdict.com/npm-ref/all.html#script-shell)
+
+git-bashの本体が置かれているパスを指定する。
+
+```shell
+$ npm config set script-shell "C:\\Program Files\\git\\bin\\bash.exe"
+$ npm config get script-shell
+C:\Program Files\git\bin\bash.exe
+```
+
+
+これで`package.json`の記述はMac環境と同様のまま `npm run dev` が実行できるようになった。
+
+## 補足
+
+ちなみに `cross-env` を導入して解決する手段もあるらしい。環境毎に条件分岐させたい場合などには、これ使うのが良いかもしれない。
+https://www.npmjs.com/package/cross-env
+
+知らんけど。


### PR DESCRIPTION
npm run実行時の構文エラー解決のため、git bashへ変更。
npm-scripts実行に使用されるシェルはプラットフォーム依存で、Windowsの場合はデフォルトでcmdが使用される形となっていた。
![2023-08-14_15h53_30](https://github.com/unsolublesugar/zenn-content/assets/8685879/e51fdc3f-e734-4a51-95d6-e227efc232fb)
