### PR TITLE
Add instructions for GitHub and Slack mention

### DIFF
--- a/articles/298c9728e01819db9f50.md
+++ b/articles/298c9728e01819db9f50.md
@@ -66,6 +66,9 @@ Web画面が開くので、対象ワークスペースを確認し「Connect Git
 
 ![](https://storage.googleapis.com/zenn-user-upload/bt265i8xmoey3fpzyrkn2bbool17)
 
+:::message
+メンバーにGitHub上のメンションとSlack上のメンション紐づけをしてもらう際も `/github signin` を打ってもらいましょう。
+:::
 
 # リポジトリの購読を開始する
 


### PR DESCRIPTION
# 概要
- SlackとGithubメンションの紐づけに関する記載を追記

![スクリーンショット 2023-12-21 12 21 16](https://github.com/unsolublesugar/zenn-content/assets/8685879/e445f9f6-8d4a-4bcb-bacd-55f2372c09f5)

## 対象記事
【Slack + GitHub連携】issueコメントやプルリク通知をチャンネルに流して開発効率を加速させる
https://zenn.dev/easy_easy/articles/298c9728e01819db9f50

