### PR TITLE
M3 mac環境での dotnet: command not found .NET Core エラー解消方法

### DIFF
--- a/articles/982e38df5ffbd9.md
+++ b/articles/982e38df5ffbd9.md
@@ -1,0 +1,83 @@
+---
+title: "M3 mac環境での dotnet: command not found .NET Core エラー解消方法"
+emoji: "🔗"
+type: "tech" # tech: 技術記事 / idea: アイデア
+topics: [dotnet, macos, zsh, arm64]
+published: false
+---
+
+# arm64版のSDKをインストール
+
+M3 Pro Mac環境のVSCode上でC#のファイルを開く機会があり、`.NET core SDK`をインストールしました。
+
+https://dotnet.microsoft.com/ja-jp/download
+
+該当環境はApple Siliconチップ搭載のMacとなるため、arm64版のSDKをダウンロードします。
+
+```
+% uname -m
+arm64
+```
+
+SDKインストール後にVSCodeを見ると、ウインドウ右下に以下のエラーメッセージが表示されました。
+
+> .NET Core SDKが見つかりません: Error running dotnet --info: Error: Command failed: dotnet --info /bin/sh: dotnet: command not found /bin/sh: dotnet: command not found .NET Core デバッグは有効になりません。.NET Core SDK がインストールされ、パス上にあることを確認します。
+
+パスが通っていないことが原因かと思い、`.zshrc`にインストールしたSDKのパスを追加。
+
+```shell
+% which dotnet               
+/usr/local/share/dotnet/dotnet
+```
+
+```.zshrc
+export DOTNET_ROOT="/usr/local/share/dotnet/dotnet"
+export PATH=$PATH:$DOTNET_ROOT
+```
+
+しかしながら、プロジェクトを開き直してもエラーが表示され続ける状況でした。
+
+# 該当issueに対処法あり
+.NET CoreはOSSプラットフォームのため、SDKのリポジトリも公開されています。
+
+https://github.com/dotnet/sdk
+
+試しに`dotnet: command not found`で検索してみると、トップにそれらしきissueがありました。
+
+> I have macOS 12.0.1
+When I open a project on visual studios, the message says that I need to install .net core 3.1. But when I download it, nothing changes and I still cannot run the the command dotnet
+I would appreciate, if someone helped me
+> 
+> Problem encountered on https://dotnet.microsoft.com/learn/dotnet/hello-world-tutorial/install
+Operating System: macos
+> 
+> Provide details about the problem you're experiencing. Include your operating system version, exact error message, code sample, and anything else that is relevant.
+>
+> https://github.com/dotnet/sdk/issues/22910
+
+
+どうやらarm64アーキテクチャであるM1チップ搭載以後のMac環境にて、同様の事象が発生するようです。ザッとコメントを見たところシンボリックリンクを作成することで解決できる様子。
+
+> After installation the symlink is missing, which is likely due to SIP (System Integrity Protection).
+> I tried to do this manually by disabling SIP and running the following command.
+>
+> `ln -s /usr/local/share/dotnet/dotnet /usr/local/bin/`
+> It creates the file just fine, however terminal still can't see it.
+> Even adding it to the PATH for .zshrc doesn't work.
+> 
+> It looks like dotnet is installed correctly, but just can't be accessed...
+> 
+> This is about as far as I have got.
+> 
+> https://github.com/dotnet/sdk/issues/22910#issuecomment-986186872
+
+
+というわけで、SDKのインストールパスのシンボリックリンクを張ります。
+
+```shell
+% ln -s /usr/local/share/dotnet/dotnet /usr/local/bin
+```
+
+この対応で無事にエラーメッセージが消えました。
+
+Apple Siliconチップ搭載Macは静音化して快適になったのはありがたいのですが、開発環境構築でこの手のトラブル多いのがなかなか厄介ですね。

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "zenn-cli": "^0.1.150"
+        "zenn-cli": "^0.1.153"
       }
     },
     "node_modules/zenn-cli": {
-      "version": "0.1.150",
-      "resolved": "https://registry.npmjs.org/zenn-cli/-/zenn-cli-0.1.150.tgz",
-      "integrity": "sha512-sf/oKEx8e74CyFQ4jwFMRKDyF9cVkDH3XrU1IhGddBvwpYYrFySZ5kKL3Wn0BVC7EiqVFMvoxjQ+nEGOoBCW9w==",
+      "version": "0.1.153",
+      "resolved": "https://registry.npmjs.org/zenn-cli/-/zenn-cli-0.1.153.tgz",
+      "integrity": "sha512-MLIdtRW2arQBuVCKlWrMF4eFZGkvmswrcc0OvgxmQs9w9/9rODfoyFK9nQQwrgyUwlxDzhUa/oAO6nks4GY5DA==",
       "bin": {
         "zenn": "dist/server/zenn.js"
       },
@@ -26,9 +26,9 @@
   },
   "dependencies": {
     "zenn-cli": {
-      "version": "0.1.150",
-      "resolved": "https://registry.npmjs.org/zenn-cli/-/zenn-cli-0.1.150.tgz",
-      "integrity": "sha512-sf/oKEx8e74CyFQ4jwFMRKDyF9cVkDH3XrU1IhGddBvwpYYrFySZ5kKL3Wn0BVC7EiqVFMvoxjQ+nEGOoBCW9w=="
+      "version": "0.1.153",
+      "resolved": "https://registry.npmjs.org/zenn-cli/-/zenn-cli-0.1.153.tgz",
+      "integrity": "sha512-MLIdtRW2arQBuVCKlWrMF4eFZGkvmswrcc0OvgxmQs9w9/9rODfoyFK9nQQwrgyUwlxDzhUa/oAO6nks4GY5DA=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   },
   "homepage": "https://github.com/unsolublesugar/zenn-content#readme",
   "dependencies": {
-    "zenn-cli": "^0.1.150"
+    "zenn-cli": "^0.1.153"
   }
 }


### PR DESCRIPTION
Apple Siliconチップ搭載Macは開発環境構築まわりのトラブルが多い

![スクリーンショット 2024-03-05 16 15 06](https://github.com/unsolublesugar/zenn-content/assets/8685879/d0903088-275c-445e-926c-3a08111838d7)
