### PR TITLE
Claude Code公式とZenn公式のfrontmatter表記の違いについて説明を追加

### DIFF
--- a/articles/ae877f07fa46df.md
+++ b/articles/ae877f07fa46df.md
@@ -238,6 +238,11 @@ topics: [claudecode, anthropic, zenn, ai, 自動化]
 ```
 
 #### Front Matter表記の統一
+
+:::message
+**表記について**: Claude Code公式ドキュメントでは「YAML frontmatter」という表記が使用されていますが（[参考](https://docs.anthropic.com/en/docs/claude-code/slash-commands#file-format)）、本記事はZennでの記事作成に関する内容のため、Zenn公式ドキュメントの表記「Front Matter」を採用しています（[参考](https://zenn.dev/zenn/articles/zenn-cli-guide)）。
+:::
+
 「frontmatter」→「Front Matter」の表記統一が必要と指摘を受け、Web検索で技術標準を調査後、プロジェクト全体で修正。**この調査の的確さにはびっくりしました。** Jekyll、GitHub Docs、Hugoの公式ドキュメントまでチェックして、ちゃんとした根拠を示してくれるんです。
 
 具体的な修正箇所：


### PR DESCRIPTION
## Summary
- Claude Code公式ドキュメントとZenn公式ドキュメントでのfrontmatter表記の違いについて説明を追加
- Claude Code: 「YAML frontmatter」
- Zenn: 「Front Matter」  
- 記事内容に応じた表記選択の背景を明記

## Test plan
- [x] 記事の「Front Matter表記の統一」セクションに説明を追加
- [x] 両方の公式ドキュメントへの参考リンクを含む
- [x] featureブランチでの作業確認

🤖 Generated with [Claude Code](https://claude.ai/code)