### PR TITLE
月次レビューIssueタイトルの日付表示を修正

### DIFF
--- a/.github/workflows/monthly-article-review.yml
+++ b/.github/workflows/monthly-article-review.yml
@@ -62,9 +62,10 @@ jobs:
         id: review
         run: |
           report_file="review-report-$(date +%Y%m).md"
+          current_date="$(date +%Y年%m月)"
           
-          cat > "$report_file" << 'EOF'
-          # 📊 月次記事レビューレポート - $(date +%Y年%m月)
+          cat > "$report_file" << EOF
+          # 📊 月次記事レビューレポート - $current_date
           
           自動生成されたレビューレポートです。以下の観点で記事を評価しました：
           


### PR DESCRIPTION
## Summary
月次記事レビューで生成されるIssueタイトルの日付が正しく表示されない問題を修正

## 問題
- Issueタイトルが「📊 月次記事レビューレポート - $(date +%Y年%m月)」と表示される
- シェル変数展開が正しく動作していない

## 修正内容
- `cat > "$report_file" << 'EOF'` のシングルクォートを削除
- 事前に `current_date` 変数で日付を取得してから使用
- これにより「📊 月次記事レビューレポート - 2025年06月」のように正しく表示される

## Test plan
- [x] ワークフローファイルの修正
- [ ] PRマージ後に手動実行してタイトル表示を確認

🤖 Generated with [Claude Code](https://claude.ai/code)