### PR TITLE
古い記事検出をGit logベースに改善

### DIFF
--- a/.github/workflows/monthly-article-review.yml
+++ b/.github/workflows/monthly-article-review.yml
@@ -88,8 +88,8 @@ jobs:
               title=$(grep "^title:" "$article" | cut -d'"' -f2 || echo "タイトル不明")
               topics=$(grep "^topics:" "$article" | cut -d'[' -f2 | cut -d']' -f1 || echo "トピック不明")
               
-              # ファイル更新日を取得
-              file_date=$(stat -c %Y "$article" 2>/dev/null || stat -f %m "$article" 2>/dev/null || echo "0")
+              # ファイルの最終commit日時を取得（Git logベース）
+              file_date=$(git log -1 --format=%ct -- "$article" 2>/dev/null || echo "0")
               current_date=$(date +%s)
               days_old=$(( (current_date - file_date) / 86400 ))
               


### PR DESCRIPTION
## Summary
月次記事レビューの古い記事検出をGit logベースに改善し、正確な日時判定を実現

## 問題
- GitHub Actions環境でファイル日時がcheckout時にリセットされる
- `stat`コマンドでは全記事が「0日前」と表示される
- 古い記事の警告機能が正常に動作しない

## 修正内容
- `stat -c %Y` → `git log -1 --format=%ct` に変更
- ファイルの最終commit日時を正確に取得
- 90日以上古い記事を確実に検出可能

## テスト結果
### ローカルテスト
- GA4記事: 730日前 → 🔴 古い記事として正しく検出
- VPN記事: 730日前 → 🔴 古い記事として正しく検出  
- Claude Code記事: 0日前 → ✅ 最新記事として正しく検出

## Test plan
- [x] Git logベースの日時取得ロジックの実装
- [x] ローカルでの動作確認
- [ ] PRマージ後に手動実行で古い記事警告の確認

🤖 Generated with [Claude Code](https://claude.ai/code)