### PR TITLE
Git履歴取得でfetch-depth: 0を追加

### DIFF
--- a/.github/workflows/monthly-article-review.yml
+++ b/.github/workflows/monthly-article-review.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # 全履歴を取得してgit logを正常動作させる
         
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
月次記事レビューでgit logが正常動作するよう、fetch-depth: 0を追加してGit履歴を完全取得

## 問題
- GitHub Actionsのデフォルトcheckoutは`fetch-depth: 1`（shallow clone）
- `git log -1 --format=%ct`が履歴不足で正常に動作しない
- 全記事が「0日前」と表示され、古い記事検出が機能しない

## 修正内容
- Checkout stepに`fetch-depth: 0`を追加
- 全Git履歴を取得してgit logコマンドを正常動作させる
- 古い記事の正確な最終commit日時を取得可能

## 期待される結果
- 730日前の古い記事 → 「⚠️ **要更新**: 90日以上更新されていません」
- 最新記事 → 「✅ **最新**: 最近更新されています」

## Test plan
- [x] fetch-depth: 0の追加
- [ ] PRマージ後に手動実行で古い記事警告の動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)