### PR TITLE
月次レビューに記事への直リンクを追加

### DIFF
--- a/.github/workflows/monthly-article-review.yml
+++ b/.github/workflows/monthly-article-review.yml
@@ -90,6 +90,17 @@ jobs:
               title=$(grep "^title:" "$article" | cut -d'"' -f2 || echo "タイトル不明")
               topics=$(grep "^topics:" "$article" | cut -d'[' -f2 | cut -d']' -f1 || echo "トピック不明")
               
+              # publication_nameとarticle_idを取得してリンクを生成
+              # Front Matter内のpublication_nameのみを取得（先頭10行から検索してコメント除外）
+              publication_name=$(head -10 "$article" | grep "^publication_name:" | grep -v "#" | cut -d'"' -f2 || echo "")
+              article_id=$(basename "$article" .md)
+              
+              if [ -n "$publication_name" ]; then
+                article_url="https://zenn.dev/$publication_name/articles/$article_id"
+              else
+                article_url="https://zenn.dev/unsoluble_sugar/articles/$article_id"
+              fi
+              
               # ファイルの最終commit日時を取得（Git logベース）
               file_date=$(git log -1 --format=%ct -- "$article" 2>/dev/null || echo "0")
               current_date=$(date +%s)
@@ -98,6 +109,7 @@ jobs:
               cat >> "$report_file" << EOF
           ### 📄 $title
           
+          **記事リンク**: $article_url  
           **ファイル**: \`$article\`  
           **トピック**: $topics  
           **最終更新**: ${days_old}日前  


### PR DESCRIPTION
## Summary
月次記事レビューに記事への直リンクを追加し、`publication_name`による個人/組織記事の判定を実装

## 機能詳細
### 記事リンク生成
- `publication_name`があれば組織記事: `https://zenn.dev/{publication_name}/articles/{article_id}`
- `publication_name`がなければ個人記事: `https://zenn.dev/unsoluble_sugar/articles/{article_id}`

### publication_name判定
- Front Matter内の`publication_name`のみを正確に取得
- コメント行（`#`含む）を除外して誤検出を防止
- 先頭10行からの検索で高速処理

## テスト結果
### 組織記事の例
- `easy_easy`記事 → `https://zenn.dev/easy_easy/articles/c50834cc069906`

### 個人記事の例  
- Claude Code記事 → `https://zenn.dev/unsoluble_sugar/articles/ae877f07fa46df`

## UI改善
レビューレポートに「**記事リンク**」項目を追加し、ワンクリックで記事を確認可能

## Test plan
- [x] publication_name検出ロジックの実装・テスト
- [x] 組織記事と個人記事の正しいURL生成確認
- [x] コメント行の除外動作確認
- [ ] PRマージ後に手動実行でリンク表示確認

🤖 Generated with [Claude Code](https://claude.ai/code)