### PR TITLE
トピック抽出機能を削除: 表示の不具合を解消

### DIFF
--- a/.github/workflows/monthly-article-review.yml
+++ b/.github/workflows/monthly-article-review.yml
@@ -88,7 +88,6 @@ jobs:
               
               # 記事の基本情報を取得
               title=$(grep "^title:" "$article" | sed 's/title: *"//' | sed 's/"$//' || echo "タイトル不明")
-              topics=$(grep "^topics:" "$article" | sed 's/topics: *//' || echo "トピック不明")
               
               # publication_nameとarticle_idを取得してリンクを生成
               # Front Matter内のpublication_nameのみを取得（先頭10行から検索してコメント除外）
@@ -111,7 +110,6 @@ jobs:
           
           **記事リンク**: $article_url  
           **ファイル**: \`$article\`  
-          **トピック**: $topics  
           **最終更新**: ${days_old}日前  
           
           #### 🔍 情報の古さチェック


### PR DESCRIPTION
## Summary
- トピック情報の抽出と表示を完全に削除
- レポート表示をよりシンプルで確実な形式に変更
- 記事基本情報の表示を整理

## 修正内容
トピック抽出で以下のような不具合が発生していました：
- 複数行にわたる表示
- 変数の重複表示
- Front Matterコメントの混入

これらを解消するため、トピック情報を削除してシンプルな表示に変更しました。

## Test plan
- [ ] ワークフローの手動実行
- [ ] レポート表示の確認
- [ ] 記事情報の正常表示確認

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>