### PR TITLE
CLAUDE.mdをSkill/Rules/Steering構成に最適化

### DIFF
--- a/.claude/rules/content-guidelines.md
+++ b/.claude/rules/content-guidelines.md
@@ -1,0 +1,32 @@
+---
+description: 記事・ブックの作成・編集時に適用（articles/, books/配下のMarkdownファイル）
+paths: ["articles/**/*.md", "books/**/*.md"]
+---
+
+# Content Guidelines
+
+## Front Matter仕様
+
+```yaml
+---
+title: "記事タイトル"
+emoji: "📝"
+type: "tech"  # tech: 技術記事 / idea: アイデア記事
+topics: [topic1, topic2]  # 最大5つまで（超過するとエラー）
+published: true  # false: 下書き
+publication_name: "publication_name"  # 任意
+---
+```
+
+## 厳守事項
+
+- **topicsは最大5つ**。超過するとZenn側でエラーになる
+- **URLは独立した行に配置**。ZennはスタンドアロンURLをカードビューとして自動展開する
+- Front Matterが不正な記事は無効扱いになる
+
+## コンテンツタイプ
+
+| type | 用途 |
+|------|------|
+| `tech` | 技術的な内容の記事 |
+| `idea` | 意見・アイデア系の記事 |

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -1,0 +1,50 @@
+---
+description: Git操作（commit, push, branch, PRなど）を行うすべての場面で適用
+---
+
+# Git Workflow Rules
+
+## 絶対原則
+
+mainブランチへの直接コミットは原則禁止。すべての変更はfeatureブランチ経由でPRを通す。
+
+**例外**: ユーザーが会話中に「mainに直接コミットしてよい」と明示的に指示した場合は、その指示に従う。
+
+## コミット前の必須手順
+
+**すべてのgit commitの前に、以下を必ず実行すること：**
+
+1. `git branch --show-current` で現在のブランチを確認
+2. mainブランチにいる場合は **即座に中断** し、featureブランチに切り替える
+3. 既存ブランチの確認: `git branch -a`
+4. 関連するfeatureブランチがあればそれを使用、なければ新規作成
+
+## ブランチ命名規則
+
+- 形式: `feature/簡潔な説明`（例: `feature/claude-code-article`）
+- 新規作成: `git checkout -b feature/description`
+
+## コミットからPRまでの流れ
+
+```bash
+# 1. ブランチ確認（必須）
+git branch --show-current
+
+# 2. featureブランチへ切り替え（mainにいる場合）
+git checkout -b feature/description
+
+# 3. 変更をコミット
+git add <対象ファイル>
+git commit -m "メッセージ"
+
+# 4. プッシュ
+git push -u origin feature/description
+
+# 5. PR作成
+gh pr create -a unsolublesugar -l enhancement
+```
+
+## PR作成ルール
+
+- `gh pr create -a unsolublesugar -l enhancement` を使用（オーナーアサイン + enhancementラベル自動付与）
+- PRの説明とテストプランを含めること

--- a/.steering/content-structure.md
+++ b/.steering/content-structure.md
@@ -1,0 +1,34 @@
+# Content Structure
+
+## リポジトリ構成
+
+```
+zenn-content/
+├── articles/          # 記事（Markdown + Front Matter）
+│   └── *.md           # ハッシュベースのファイル名（例: 5330b19412687ee0b435.md）
+├── books/             # ブック（長編コンテンツ）
+├── .claude/
+│   └── rules/         # Claude Code向け行動規約
+├── .steering/         # プロジェクト背景知識
+└── CLAUDE.md          # エントリポイント
+```
+
+## Zennプラットフォームとの連携
+
+- publishedがtrueの記事は、GitHubへのpush時にZennへ自動同期される
+- ビルドプロセスやテストフレームワークは存在しない（純粋なMarkdownベース）
+- 記事のプレビューは `npx zenn preview` でローカル確認
+
+## 記事ファイルの構造
+
+各記事は以下の構成:
+1. **Front Matter**（YAML）: メタデータ（タイトル、絵文字、タイプ、トピック、公開状態）
+2. **本文**（Markdown）: 記事コンテンツ（日本語）
+
+## 開発フロー
+
+1. `npx zenn preview` でローカルサーバー起動
+2. `npx zenn new:article` で新規記事のテンプレート生成
+3. `articles/` 配下のMarkdownを編集
+4. ブラウザでプレビュー確認
+5. featureブランチからPRを作成（Git運用ルールは `.claude/rules/git-workflow.md` 参照）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,99 +1,30 @@
 # CLAUDE.md
+
 必ず日本語で回答してください。
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Repository Overview
+## Project
 
-This is a Zenn content repository containing Japanese technical articles and books. Zenn is a Japanese developer platform for sharing technical knowledge.
+Zenn（日本の技術情報共有プラットフォーム）向けのコンテンツリポジトリ。記事・本はすべて日本語で執筆。
 
-## Key Commands
+## Commands
 
-### Content Management
-- `npx zenn preview` - Preview content in browser (most frequently used)
-- `npx zenn new:article` - Create new article
-- `npx zenn new:book` - Create new book 
-- `npx zenn list:articles` - List all articles
-- `npx zenn list:books` - List all books
+| コマンド | 用途 |
+|---------|------|
+| `npx zenn preview` | ブラウザでプレビュー |
+| `npx zenn new:article` | 新規記事作成 |
+| `npx zenn new:book` | 新規ブック作成 |
+| `npx zenn list:articles` | 記事一覧 |
+| `npx zenn list:books` | ブック一覧 |
+| `npm install` | 依存パッケージインストール |
 
-### Package Management
-- `npm install` - Install dependencies (primarily zenn-cli)
+## Zenn Dashboard
 
-## Content Structure
+| リンク | 用途 |
+|--------|------|
+| https://zenn.dev/dashboard/uploader | 画像アップロード |
+| https://zenn.dev/dashboard | ダッシュボード |
 
-### Articles
-- Located in `articles/` directory
-- Each article is a Markdown file with Front Matter
-- Front Matter includes: title, emoji, type (tech/idea), topics, published status
-- Articles use unique hash-based filenames (e.g., `5330b19412687ee0b435.md`)
+## References
 
-### Books
-- Located in `books/` directory
-- Structure for longer-form content
-
-## Content Guidelines
-
-### Front Matter Format
-```yaml
----
-title: "Article Title"
-emoji: "📝"
-type: "tech" # or "idea"
-topics: [javascript, react, etc] # Maximum 5 topics allowed
-published: true # or false
-publication_name: "publication_name" # optional
----
-```
-
-### Content Types
-- `tech`: Technical articles
-- `idea`: Opinion/idea articles
-
-## Development Workflow
-
-### Content Development
-1. Use `npx zenn preview` to start development server
-2. Create new content with `npx zenn new:article` or `npx zenn new:book`
-3. Edit Markdown files in `articles/` or `books/`
-4. Preview changes in browser before publishing
-
-### Git Workflow Rules - STRICTLY ENFORCE
-**NEVER commit directly to main branch. Always use feature branches.**
-
-#### Before ANY git commit:
-1. **ALWAYS check current branch first**: `git branch --show-current`
-2. **If on main branch**: STOP and switch to appropriate branch
-3. **Branch selection strategy**:
-   - Check existing branches: `git branch -a`
-   - Use existing feature branch if relevant (e.g., `feature/claude-code-zenn-analysis-article`)
-   - Create new feature branch if needed: `git checkout -b feature/description`
-
-#### Required Git Commands Sequence:
-```bash
-# 1. Check current branch (MANDATORY)
-git branch --show-current
-
-# 2. If on main, switch to feature branch
-git checkout feature/appropriate-branch-name
-# OR create new branch
-git checkout -b feature/new-feature-name
-
-# 3. Then proceed with normal git workflow
-git add .
-git commit -m "message"
-git push
-```
-
-#### Pull Request Workflow:
-- All changes must go through Pull Requests
-- No direct commits to main branch allowed
-- Use `gh pr create -a unsolublesugar -l enhancement` for PR creation (automatically assigns repository owner and adds enhancement label)
-- Include appropriate PR descriptions and test plans
-
-## Important Notes
-
-- All content is in Japanese
-- Articles must have proper Front Matter to be valid
-- **Topics must be limited to maximum 5 items** - exceeding this limit causes errors
-- **URLs should be placed on separate lines for card view display** - Zenn automatically generates preview cards for standalone URLs
-- Published articles are automatically synced to Zenn platform
-- No build process or testing framework - content is purely Markdown-based
+- Rules: `.claude/rules/` — Git運用・コンテンツ規約
+- Steering: `.steering/` — プロジェクト構造・Zenn仕様の背景知識


### PR DESCRIPTION
## Summary
- CLAUDE.mdをエントリポイントとして簡潔化し、詳細を`.claude/rules/`と`.steering/`に分離
- Gitワークフロールールを`.claude/rules/git-workflow.md`に独立させ、自動適用による強制力を向上
- コンテンツガイドラインを`.claude/rules/content-guidelines.md`に分離（`paths`指定で記事編集時に自動適用）
- Zennダッシュボード（画像アップロード等）へのリンクをCLAUDE.mdに追加

## Test plan
- [ ] `npx zenn preview`でプレビューが正常動作すること
- [ ] Claude Codeでgit操作時にgit-workflowルールが適用されること
- [ ] 記事編集時にcontent-guidelinesが適用されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)