### PR TITLE
完全に理解したTalk #76 のイベントレポート記事を追加

### DIFF
--- a/articles/ac26a2edcc7729.md
+++ b/articles/ac26a2edcc7729.md
@@ -1,0 +1,88 @@
+---
+title: "エンジニア達の「完全に理解した」Talk #76 イベントレポート"
+emoji: "📝"
+type: "idea" # tech: 技術記事 / idea: アイデア
+topics: [勉強会, イベント, npm, gemini, terraform]
+published: true
+publication_name: "easy_easy"
+---
+
+# エンジニア達の「完全に理解した」Talk #76
+
+2026年4月28日にオンライン開催した、完全に理解したTalkのスライド資料と概要まとめです。
+
+> 完全に理解した、それはまさに「分かった気になったくらい」の理解できたくらいのもの！「覚えたての知識」や「この知識なら自信出てきた！」みたいなものから「あれ、ちょっと怪しいかも？」となり始めた知識まで自分が話したい知識をなんでもゆるーく話をする会です！
+>
+> みんなにOUTPUTして、是非自分の実力を高めちゃいましょう！
+>
+> [完全に理解したTalk #76 - Easy Easy](https://easy2.connpass.com/event/389739/)
+
+# LT1: npm パッケージ公開を完全に理解した（[@ic_lifewood](https://x.com/ic_lifewood)）
+@[docswell](https://www.docswell.com/s/ic_lifewood/KWRX2X-2026-04-28-182011)
+
+- npm パッケージ公開は単にコマンドを実行するだけでなく「いつでも同じ品質で公開できる仕組みを作る」ことが重要
+- バージョン番号は [SemVer (Semantic Versioning)](https://semver.org/lang/ja/) に従って `MAJOR.MINOR.PATCH` で運用
+- コミット規約は [Conventional Commits](https://www.conventionalcommits.org/ja/) を [@commitlint/cli](https://www.npmjs.com/package/@commitlint/cli) + [@commitlint/config-conventional](https://www.npmjs.com/package/@commitlint/config-conventional) + [husky](https://typicode.github.io/husky/) で強制
+- Issue / PR / CONTRIBUTING / LICENSE / README を多言語対応のテンプレートで整備
+- API ドキュメントは [TypeDoc](https://typedoc.org/) と [typedoc-rhineai-theme](https://www.npmjs.com/package/typedoc-rhineai-theme) で自動生成し [GitHub Pages](https://pages.github.com/) へデプロイ
+- [GitHub Actions](https://docs.github.com/ja/actions) で `ci.yml` / `commitlint.yml` / `deploy-docs.yml` / `release.yml` を分けて自動化
+- 公開は [npm Trusted Publishing (OIDC)](https://docs.npmjs.com/trusted-publishers) で GitHub Actions から認証情報なしに実施
+- `npm pack --dry-run` で同梱物を事前検証し、壊れた成果物の公開を防止
+- 公開後の確認は [npmx.dev](https://npmx.dev/) などで実施
+- 題材プロジェクト: [@gurezo/web-serial-rxjs](https://www.npmjs.com/package/@gurezo/web-serial-rxjs)（[GitHub リポジトリ](https://github.com/gurezo/web-serial-rxjs)）
+
+# LT2: さよなら、マウント 〜AIを利用して、不毛なやり取りを終わらせよう〜（[@YURUMANGAmanga](https://x.com/YURUMANGAmanga)）
+<!-- スライド公開時に下記コメントを外して埋め込み記法に置き換える -->
+<!-- @[docswell](URL) -->
+<!-- @[speakerdeck](ID) -->
+
+- 公共建築の音響設計や役所協議を担う技術者である発表者が、組織のルールを盾にマウントを取ってくる総務担当者や、資料の中身ではなくレイアウトばかりを指摘する上司との不毛なやり取りを AI で解消した事例
+- 解決策は [Gemini](https://gemini.google.com/) の [Gem](https://gemini.google.com/gems/view) 機能で専属アシスタント「**エンジェル**」を育成。3ステップで運用：
+    1. **知識の取り込み**: 社内の総務規程・出張・経費精算ルールを学習させる
+    2. **癖の学習**: 担当者の言い回しや上司が過去に作った PDF 資料を読み込ませ、レイアウトの好み（余白・フォント・言い回し）を把握させる
+    3. **インターフェース整備**: 社内共有し、`カテゴリー` などのトリガーで一覧表示できるよう仕込む
+- 事務作業はエンジェルが先回りで案内し、資料を投げるだけで上司の癖に沿ったレイアウト指摘が返ってくるように
+- 結果、チェックバックがほぼゼロになり、本来の創造的業務に時間を割けるように
+- 締めは **「さよなら、マウント。あなたの仕事は自動化されました。」**
+
+# LT3: GoogleCloudとterraform完全に理解した（[@cor_terisuke](https://x.com/cor_terisuke)）
+@[speakerdeck](d42e326199b24919b2a492b2819b274a)
+
+- コロナ禍で無職 → トランペット奏者 → AI 営業 → 未経験エンジニアとして起業し3期目、本回が **記念すべき100週連続登壇**
+- クラウド AI の API 課金高騰を受け「インフラを他人に握らせるな」と決意し、[Google Cloud](https://cloud.google.com/) 上に自分専用の AI 環境を構築。インフラは [Terraform](https://www.terraform.io/) でコード管理し、`plan` → `apply` でポチポチ作業を排除
+- モデルは [Qwen3.5 9B](https://qwenlm.github.io/) （軽量）と Qwen3.5 35B-A3B（MoE 中規模）を用途で使い分け、コーディング向けには [GLM-4.7 flash](https://github.com/THUDM/GLM-4) を採用。[Vertex AI](https://cloud.google.com/vertex-ai) 上の [Gemini API](https://ai.google.dev/) も併用
+- 1時間約1,303円のコスト試算に対し、「平日 8〜22 時稼働・土日完全停止」のスケジュールで月数万円規模に抑える計画だった
+- **落とし穴1**: Terraform でスケーリング上限を `0` に書き換えて `apply` が成功しても、すでに起動中の GPU インスタンスには即時反映されず、夜間も土日も動き続けていた
+- **落とし穴2**: Google Cloud には予算アラートはあるが「金額超で強制停止」のハードリミットは無い（[Cloud Functions](https://cloud.google.com/functions) で自作可能だが現実的に組んでいる人は少ない）
+- 結果、1日約3.6万円を溶かし月間請求は **約50万〜60万円**。Google サポートに泣きついたが過去（発表者本人の Gemini API 利用時）の救済前例があり今回は救済なし
+- 教訓: `terraform apply` の成功は期待通りに動くことを保証しない／「アラートはあるがリミットはない」という語呂のいい罠
+- 最終結論は **「オンプレミス is GOD」**。[GMKtec EVO-X2](https://www.gmktec.com/) （Ryzen AI Max+ 395 / メモリ128GB）に [Ubuntu](https://ubuntu.com/) と Qwen3.5 系モデルを入れて AI サーバ化、[Tailscale](https://tailscale.com/) + WebUI で快適運用
+
+# 動画アーカイブ
+
+@[youtube](YhuglqlmDUw)
+
+各セクション開始タイムスタンプ:
+
+- [00:00](https://www.youtube.com/watch?v=YhuglqlmDUw&t=0s) 前座
+- [11:27](https://www.youtube.com/watch?v=YhuglqlmDUw&t=687s) 運営紹介
+- [27:41](https://www.youtube.com/watch?v=YhuglqlmDUw&t=1661s) LT1: npm パッケージ公開を完全に理解した
+- [56:29](https://www.youtube.com/watch?v=YhuglqlmDUw&t=3389s) LT2: さよなら、マウント 〜AIを利用して、不毛なやり取りを終わらせよう〜
+- [1:14:15](https://www.youtube.com/watch?v=YhuglqlmDUw&t=4455s) LT3: GoogleCloudとterraform完全に理解した
+- [1:35:15](https://www.youtube.com/watch?v=YhuglqlmDUw&t=5715s) クロージング
+
+# 関連リンク
+
+## 🌐ポータルサイト
+https://easy2.jp/
+
+## 📝コミュニティ運営紹介記事
+https://zenn.dev/easy_easy/articles/3534caabc4f028
+
+https://zenn.dev/easy_easy/articles/89318e4d0acb4f
+
+## 🙌connpassコミュニティページ
+https://easy2.connpass.com/
+
+## 📺️『Easy Easy』YouTubeチャンネル
+https://www.youtube.com/@talk9929


### PR DESCRIPTION
## Summary

- 2026年4月28日にオンライン開催した「完全に理解したTalk 76」のイベントレポート記事を追加
- LT1（npm パッケージ公開）は Docswell スライドを `@[docswell]` で埋め込み、スライド内で紹介された各 OSS（SemVer / Conventional Commits / commitlint / husky / TypeDoc / GitHub Actions / npm Trusted Publishing 等）への公式リンクを併記
- LT2（AI を利用してマウントを解消）は Gemini の Gem 機能でアシスタント「エンジェル」を育成する3ステップを整理
- LT3（Google Cloud + Terraform で約50〜60万円の高額請求失敗談）は Speaker Deck スライドを `@[speakerdeck]` で埋め込み、Qwen3.5 9B / 35B-A3B / GLM-4.7 flash / Vertex AI / Cloud Functions / GMKtec EVO-X2 などへの公式リンクを併記
- アーカイブ動画を `@[youtube](YhuglqlmDUw)` で埋め込み、各セクション開始タイムスタンプを YouTube `&t=Xs` リンクで一覧化
- 末尾にコミュニティポータルサイト easy2.jp / connpass / YouTube チャンネルへの導線

## Test plan

- [x] `npx zenn list:articles` で Frontmatter が valid であることを確認
- [x] `npx zenn preview` で動画埋め込み・Docswell / Speaker Deck 埋め込み・関連リンクのカードビューを目視確認
- [x] マージ後、Zenn 上で表示崩れがないか確認
- [x] LT2 のスライドが共有された際に HTML コメント枠を `@[docswell]` または `@[speakerdeck]` に置き換える

🤖 Generated with [Claude Code](https://claude.com/claude-code)