### PR TITLE
完全に理解したTalk #74 のイベントレポート記事を追加

### DIFF
--- a/articles/137eb74f6f5996.md
+++ b/articles/137eb74f6f5996.md
@@ -1,0 +1,93 @@
+---
+title: "エンジニア達の「完全に理解した」Talk #74 イベントレポート"
+emoji: "📝"
+type: "idea" # tech: 技術記事 / idea: アイデア
+topics: [勉強会, イベント, postgresql, tcp, gemma]
+published: true
+publication_name: "easy_easy"
+---
+
+# エンジニア達の「完全に理解した」Talk #74
+
+2026年2月24日にオンライン開催した、完全に理解したTalkのスライド資料と概要まとめです。
+
+> 完全に理解した、それはまさに「分かった気になったくらい」の理解できたくらいのもの！「覚えたての知識」や「この知識なら自信出てきた！」みたいなものから「あれ、ちょっと怪しいかも？」となり始めた知識まで自分が話したい知識をなんでもゆるーく話をする会です！
+>
+> みんなにOUTPUTして、是非自分の実力を高めちゃいましょう！
+>
+> [完全に理解したTalk #74 - Easy Easy](https://easy2.connpass.com/event/383400/)
+
+# LT1: わかった気になる TCP BBR（[@mti_daiki](https://x.com/mti_daiki)）
+
+@[speakerdeck](0aa4be62caad4a95bd1a2fa60530d2e4)
+
+- インターネットの輻輳（混雑）制御に関する、Googleの新しいアルゴリズム **[TCP BBR](https://research.google/pubs/bbr-congestion-based-congestion-control/)** を解説
+- 従来のロスベースのアルゴリズム（[CUBIC](https://datatracker.ietf.org/doc/html/rfc8312) など）は、ルーターのバッファが溢れて [パケットロス](https://en.wikipedia.org/wiki/Packet_loss) が発生するまでデータを送り続けるため、**[キューイング遅延](https://en.wikipedia.org/wiki/Queuing_delay)（バッファブロート）** が発生する点が課題
+- TCP BBR はボトルネックリンクの帯域幅をフルに使いつつ、キューイング遅延を発生させないよう賢くデータを送るアプローチを取る
+- 理想とするのは、バッファを空にして遅延を最小に保ちながら、送信レートが最大（ボトルネックリンクの帯域幅）である状態
+- BBR は **BDP（[Bandwidth-Delay Product](https://en.wikipedia.org/wiki/Bandwidth-delay_product): 帯域幅と遅延の積）** という概念を導入し、ネットワーク中を流れるデータ量（インフライトデータ量）を BDP に保つように送信レートをコントロールする
+- 帯域幅と遅延を同時に正確に測ることはできない（帯域幅を知るために送信量を増やすと遅延が発生する）ジレンマがあるため、BBR は4つのモード（`STARTUP` / `DRAIN` / `PROBE_BW` / `PROBE_RTT`）を行き来してネットワーク状況の探索・推定を行っている
+
+# LT2: postgreSQLだと外部参照キーにデフォルトでインデックスが張られていない（[@taiyama1212](https://x.com/taiyama1212)）
+
+@[speakerdeck](224acd0670de4de5b4e6d1e4f33594ef)
+
+- 外部参照キー（[外部キー](https://www.postgresql.jp/document/current/html/tutorial-fk.html)）に [インデックス](https://www.postgresql.jp/document/current/html/indexes.html) を貼るべきかについて、[PostgreSQL](https://www.postgresql.org/) と [MySQL](https://www.mysql.com/) の挙動の違いを調査した報告
+- **MySQL** では外部キー制約を作成すると [デフォルトでインデックスが自動作成される](https://dev.mysql.com/doc/refman/8.0/ja/create-table-foreign-keys.html)
+- 一方 **PostgreSQL** では、外部参照キーに **デフォルトでインデックスは作成されない**
+- **なぜインデックスが必要か**: 親テーブルの行を `DELETE` または `UPDATE` する際、参照整合性チェックのために子テーブルを検索する処理が走る。インデックスがないと、データ量が多い場合に [シーケンシャルスキャン](https://www.postgresql.jp/document/current/html/using-explain.html) で時間がかかってしまう
+- 結論として、PostgreSQL では基本的に **外部参照キーにはインデックスを貼る方が良い**
+- ただしデータ量が少ない、検索が行われない、更新頻度が高いといった状況では、本当にインデックスが必要かその都度検討することが推奨される
+
+# LT3: Googleの翻訳特化のAIモデル TranslateGemma 試してみる（[@mikene_koko](https://x.com/mikene_koko)）
+
+- Google の [Gemma 2](https://ai.google.dev/gemma) を基盤とした翻訳特化のオープンソース LLM **TranslateGemma** を検証
+- 強みは、サポート言語が **55言語** と非常に多く、[サポテク語](https://en.wikipedia.org/wiki/Zapotec_languages)（メキシコの先住民言語）のようなマイナー言語（低リソース言語）にも対応している点。また、ローカルで無料で動き、データが外部に出ない点も魅力
+- 弱みは **基本的に英語への変換しかサポートしていない** こと。他言語から直接日本語へ変換することはできず、一度英語を挟む必要がある
+- 検証の結果、英語・日本語間の一般的な翻訳は問題ないレベルだが、**固有名詞の翻訳に弱い** 傾向（「虎の穴」が「虎の姉」になる等）があり、マイナー言語の精度はまだ低いことがわかった
+- ローカルで動く点や固有名詞を覚えさせれば専用翻訳機として使える可能性はあるものの、単純な翻訳用途であれば、現状は [ChatGPT](https://chatgpt.com/) などに軍配が上がるという評価
+
+# LT4: uLoopMCP × Claude Code 〜 AI駆動でUnityゲーム開発してみた（[@unsoluble_sugar](https://x.com/unsoluble_sugar)）
+
+@[docswell](https://www.docswell.com/s/unsoluble_sugar/KYVY7E-2026-02-20-182013)
+
+- [Unity](https://unity.com/) エディターを [MCP（Model Context Protocol）](https://modelcontextprotocol.io/) 経由で AI（[Claude Code](https://www.anthropic.com/claude-code) など）に直接操作させる **[uLoopMCP](https://github.com/hatayama/uLoopMCP)** を用いたゲーム開発の検証
+- Unity 開発における手動でのエディター操作を AI に委譲可能で、コンパイル、エラー検出、ヒエラルキー構造の把握、動作確認（スクリーンショット撮影）からテスト実行までを一貫して自動化できる
+- 簡単なブロック崩しゲームを題材に、[Claude の Plan Mode](https://code.claude.com/docs/ja/common-workflows#plan-mode-を使用して安全なコード分析を行う) で仕様を策定。AI が自律的にオブジェクト配置、スクリプト生成、コンパイル、動作確認およびエラー修正を行った
+- 開発者はプロンプトでの指示出しのみで、2D 版の完成から 3D 版への移行もスムーズに行うことができ、合計18のスクリプトと全シーン構築を完了させた
+- 人間はバグ修正やバランス調整、方向性の決定などに集中できるため、**AI 駆動による Unity ゲーム開発の有用性の高さ** を実感できた
+
+:::message
+本LTは2026年2月時点の検証内容です。発表当時の `uLoopMCP` は現在 **[Unity CLI Loop](https://github.com/hatayama/unity-cli-loop)** に名称変更されており、MCP ではなく CLI ツールがメインとなっています。
+:::
+
+https://zenn.dev/unsoluble_sugar/articles/cd8d59be7b8f85
+
+# 動画アーカイブ
+
+@[youtube](PmiiVF4-Mvs)
+
+各セクション開始タイムスタンプ:
+
+- [00:00](https://www.youtube.com/watch?v=PmiiVF4-Mvs&t=0s) 前座
+- [10:20](https://www.youtube.com/watch?v=PmiiVF4-Mvs&t=620s) 運営紹介
+- [22:23](https://www.youtube.com/watch?v=PmiiVF4-Mvs&t=1343s) LT1: わかった気になる TCP BBR
+- [44:57](https://www.youtube.com/watch?v=PmiiVF4-Mvs&t=2697s) LT2: postgreSQLだと外部参照キーにデフォルトでインデックスが張られていない
+- [56:39](https://www.youtube.com/watch?v=PmiiVF4-Mvs&t=3399s) LT3: Googleの翻訳特化のAIモデル TranslateGemma 試してみる
+- [1:24:41](https://www.youtube.com/watch?v=PmiiVF4-Mvs&t=5081s) LT4: uLoopMCP × Claude Code 〜 AI駆動でUnityゲーム開発してみた
+
+# 関連リンク
+
+## 🌐ポータルサイト
+https://easy2.jp/
+
+## 🙌connpassコミュニティページ
+https://easy2.connpass.com/
+
+## 📺️『Easy Easy』YouTubeチャンネル
+https://www.youtube.com/@talk9929
+
+## 📝コミュニティ運営紹介記事
+https://zenn.dev/easy_easy/articles/3534caabc4f028
+
+https://zenn.dev/easy_easy/articles/89318e4d0acb4f

--- a/articles/137eb74f6f5996.md
+++ b/articles/137eb74f6f5996.md
@@ -32,11 +32,11 @@ publication_name: "easy_easy"
 
 @[speakerdeck](224acd0670de4de5b4e6d1e4f33594ef)
 
-- 外部参照キー（[外部キー](https://www.postgresql.jp/document/current/html/tutorial-fk.html)）に [インデックス](https://www.postgresql.jp/document/current/html/indexes.html) を貼るべきかについて、[PostgreSQL](https://www.postgresql.org/) と [MySQL](https://www.mysql.com/) の挙動の違いを調査した報告
+- 外部参照キー（[外部キー](https://www.postgresql.jp/document/current/html/tutorial-fk.html)）に [インデックス](https://www.postgresql.jp/document/current/html/indexes.html) を張るべきかについて、[PostgreSQL](https://www.postgresql.org/) と [MySQL](https://www.mysql.com/) の挙動の違いを調査した報告
 - **MySQL** では外部キー制約を作成すると [デフォルトでインデックスが自動作成される](https://dev.mysql.com/doc/refman/8.0/ja/create-table-foreign-keys.html)
 - 一方 **PostgreSQL** では、外部参照キーに **デフォルトでインデックスは作成されない**
 - **なぜインデックスが必要か**: 親テーブルの行を `DELETE` または `UPDATE` する際、参照整合性チェックのために子テーブルを検索する処理が走る。インデックスがないと、データ量が多い場合に [シーケンシャルスキャン](https://www.postgresql.jp/document/current/html/using-explain.html) で時間がかかってしまう
-- 結論として、PostgreSQL では基本的に **外部参照キーにはインデックスを貼る方が良い**
+- 結論として、PostgreSQL では基本的に **外部参照キーにはインデックスを張る方が良い**
 - ただしデータ量が少ない、検索が行われない、更新頻度が高いといった状況では、本当にインデックスが必要かその都度検討することが推奨される
 
 # LT3: Googleの翻訳特化のAIモデル TranslateGemma 試してみる（[@mikene_koko](https://x.com/mikene_koko)）


### PR DESCRIPTION
## Summary
- 2026年2月24日開催の「完全に理解したTalk 74」のイベントレポート記事を追加
- LT1〜LT4（TCP BBR / PostgreSQL外部キーとインデックス / TranslateGemma / uLoopMCP × Claude Code）の概要・スライド埋め込み・関連リンクを掲載
- 既存の 75・76 と同一の体裁（導入 → 各LT → 動画アーカイブ → 関連リンク）で統一
- LT4 には発表当時の `uLoopMCP` が現在 Unity CLI Loop に名称変更されている旨の補足を追加

## Test plan
- [x] `npx zenn preview` でローカルプレビュー表示を確認
- [x] SpeakerDeck / Docswell / YouTube の埋め込みが正しく表示されること
- [x] 各外部リンク（Plan Mode / Unity CLI Loop / 関連記事など）の遷移先が正しいこと
- [x] Front Matter（topics 5件以下、publication_name 等）に問題がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)