### PR TITLE
完全に理解したTalk #73 のイベントレポート記事を追加

### DIFF
--- a/articles/8a92c47f0b3d51.md
+++ b/articles/8a92c47f0b3d51.md
@@ -1,0 +1,65 @@
+---
+title: "エンジニア達の「完全に理解した」Talk #73 イベントレポート"
+emoji: "📝"
+type: "idea" # tech: 技術記事 / idea: アイデア
+topics: [勉強会, イベント, smtp, シリアル通信, rxjs]
+published: true
+publication_name: "easy_easy"
+---
+
+# エンジニア達の「完全に理解した」Talk #73
+
+2026年1月27日にオンライン開催した、完全に理解したTalkのスライド資料と概要まとめです。
+
+> 完全に理解した、それはまさに「分かった気になったくらい」の理解できたくらいのもの！「覚えたての知識」や「この知識なら自信出てきた！」みたいなものから「あれ、ちょっと怪しいかも？」となり始めた知識まで自分が話したい知識をなんでもゆるーく話をする会です！
+>
+> みんなにOUTPUTして、是非自分の実力を高めちゃいましょう！
+>
+> [完全に理解したTalk #73 - Easy Easy](https://easy2.connpass.com/event/380365/)
+
+# LT1: SMTP完全に理解した（[@taiyama1212](https://x.com/taiyama1212)）
+
+- メール送信プロトコル [SMTP（Simple Mail Transfer Protocol）](https://datatracker.ietf.org/doc/html/rfc5321) はインターネット黎明期から使われているが、デフォルトでは **認証機能を持たない** ため、身元を隠してメール送信ができる（なりすましが可能）という構造的な課題を抱える
+- この課題への対応として拡張版の **[ESMTP（Extended SMTP）](https://datatracker.ietf.org/doc/html/rfc5321#section-2.2)** が生まれ、[SMTP-AUTH](https://datatracker.ietf.org/doc/html/rfc4954) によってサーバー側が送信元の正当性を確認できるようになった
+- 発表では、ターミナルから Gmail の SMTP サーバーに接続し、Base64 でエンコードした認証情報を `AUTH LOGIN` コマンドで渡して自分宛てにメール送信を行うライブデモも実施
+- 取り組みの背景には、発表者が業務で [Go](https://go.dev/) から [SendGrid](https://sendgrid.com/) に接続する処理を読んだことをきっかけに「いつも使っているメール送信の裏側で何が起きているのか」を掘り下げてみたかった、という経緯がある
+- 普段はライブラリ任せで意識しないプロトコルでも、コードやターミナルで直接叩いてみることで「メール送信の裏側」が一気に解像度高くイメージできるようになる、という気付きが共有された
+
+https://qiita.com/yamatai12/items/125cd409568036a0d1e2
+
+# LT2: Web Serial を完全に理解した（[@ic_lifewood](https://x.com/ic_lifewood)）
+
+@[docswell](https://www.docswell.com/s/ic_lifewood/KN9W4G-2026-01-27-191628)
+
+- ブラウザから直接ハードウェアと [シリアル通信](https://en.wikipedia.org/wiki/Serial_communication) ができる **[Web Serial API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Serial_API)** を解説
+- ブラウザごとの対応状況には思想の違いがあり、利便性を重視する Chrome など [Chromium](https://www.chromium.org/Home/) 系ブラウザは対応する一方、Firefox や Safari はハッキングや悪用などのセキュリティ上の懸念から **あえて非対応** の立場を取っている
+- Web Serial API をそのまま扱うと、読み書きそれぞれに `while` ループを抱える二重ループ構造となり実装が複雑化しがち
+- そこで非同期通信ライブラリ [RxJS](https://rxjs.dev/) で API をラップし、[Observable](https://rxjs.dev/guide/observable) ベースで簡潔に記述できる自作の npm パッケージ **[@gurezo/web-serial-rxjs](https://www.npmjs.com/package/@gurezo/web-serial-rxjs)** を開発・公開
+- 発表中には [Raspberry Pi Zero](https://www.raspberrypi.com/products/raspberry-pi-zero/) にブラウザからシリアル通信で接続し、Linux コマンドを叩いて応答を受け取るライブデモも実施
+
+https://github.com/gurezo/web-serial-rxjs
+
+# 動画アーカイブ
+
+@[youtube](ByrYv9c-VXc)
+
+各セクション開始タイムスタンプ:
+
+- [19:06](https://www.youtube.com/watch?v=ByrYv9c-VXc&t=1146s) LT1: SMTP完全に理解した
+- [38:50](https://www.youtube.com/watch?v=ByrYv9c-VXc&t=2330s) LT2: Web Serial を完全に理解した
+
+# 関連リンク
+
+## 🌐ポータルサイト
+https://easy2.jp/
+
+## 🙌connpassコミュニティページ
+https://easy2.connpass.com/
+
+## 📺️『Easy Easy』YouTubeチャンネル
+https://www.youtube.com/@talk9929
+
+## 📝コミュニティ運営紹介記事
+https://zenn.dev/easy_easy/articles/3534caabc4f028
+
+https://zenn.dev/easy_easy/articles/89318e4d0acb4f


### PR DESCRIPTION
## Summary

- 2026年1月27日にオンライン開催した「[完全に理解したTalk #73](https://easy2.connpass.com/event/380365/)」のイベントレポート記事を追加
- LT1「SMTP完全に理解した（[@taiyama1212](https://x.com/taiyama1212)）」と LT2「Web Serial を完全に理解した（[@ic_lifewood](https://x.com/ic_lifewood)）」の2発表をまとめ
- 動画アーカイブ・スライド資料・関連リポジトリへのリンクを `#74`〜`#76` と同体裁で構成

## Test plan

- [x] `npx zenn preview` でローカル表示確認済み
- [x] Front Matter（topics 5件以下、type、publication_name）が正しく解釈される
- [x] スタンドアロンURLが Zenn 上でカードビュー展開される
- [x] 動画アーカイブのタイムスタンプリンクが該当箇所へジャンプする

🤖 Generated with [Claude Code](https://claude.com/claude-code)