### PR TITLE
完全に理解したTalk #70 のイベントレポート記事を追加

### DIFF
--- a/articles/252d4d1a412ce4.md
+++ b/articles/252d4d1a412ce4.md
@@ -1,0 +1,75 @@
+---
+title: "エンジニア達の「完全に理解した」Talk #70 イベントレポート"
+emoji: "📝"
+type: "idea" # tech: 技術記事 / idea: アイデア
+topics: [勉強会, イベント, googlecloud, lt, go]
+published: true
+publication_name: "easy_easy"
+---
+
+# エンジニア達の「完全に理解した」Talk #70
+
+2025年10月28日にオンライン開催した、完全に理解したTalkのスライド資料と概要まとめです。
+
+> 完全に理解した、それはまさに「分かった気になったくらい」の理解できたくらいのもの！「覚えたての知識」や「この知識なら自信出てきた！」みたいなものから「あれ、ちょっと怪しいかも？」となり始めた知識まで自分が話したい知識をなんでもゆるーく話をする会です！
+>
+> みんなにOUTPUTして、是非自分の実力を高めちゃいましょう！
+>
+> [完全に理解したTalk #70 - Easy Easy](https://easy2.connpass.com/event/371136/)
+
+# LT1: 続・Google Cloud を完全に理解した（[@ic_lifewood](https://x.com/ic_lifewood)）
+
+@[docswell](https://www.docswell.com/s/ic_lifewood/KEYMP8-2025-10-28-205528)
+
+- 過去の登壇で失敗した「自動デプロイ」へのリベンジとして、[GitHub Actions](https://github.com/features/actions) から [Google Cloud](https://cloud.google.com/)（[Cloud Run](https://cloud.google.com/run)）へ安全にデプロイするワークフローの実装方法を解説した発表
+- 従来のサービスアカウントキー（JSON）方式は **漏洩リスクが高く**、長期間有効な認証情報をリポジトリ側に持たせる必要があるため運用上の課題があった
+- これを解決する仕組みとして **[Workload Identity Federation（WIF）](https://cloud.google.com/iam/docs/workload-identity-federation)** を採用し、GitHub Actions の OIDC トークンを Google Cloud 側で検証することで、**秘密鍵を持たずに一時的な認証トークンを発行** できるようになる
+- 設定手順としては、Google Cloud 側で Workload Identity Pool / Provider を作成し、サービスアカウントへのインパーソネートを許可した上で、GitHub Actions のワークフローから [`google-github-actions/auth`](https://github.com/google-github-actions/auth) を呼び出す流れが紹介された
+- 鍵管理の手間や漏洩リスクから解放されるだけでなく、**GitHub リポジトリやブランチ単位で権限を細かく制御** できる点が WIF の大きな利点として強調された
+
+# LT2: LT完全に理解した（[@cor_terisuke](https://x.com/cor_terisuke)）
+
+@[speakerdeck](d646880b16eb4da18566b9fdd3aa5386)
+
+- **74週連続で登壇した経験** に基づく、LT のコツとマインドセットを共有する発表
+- 短い時間で伝えるためのコツとして、**「目的を1つだけ決める」** ことが最重要で、欲張らずに伝えたいメッセージを絞り込むことが効果的
+- スライドを先に作るのではなく **「先に台本を作って流れを客観視する」** ことで、話の構成や流れを整えてからスライドに落とし込むほうが完成度が高くなる
+- 完璧を求めずまずは参加登録をしてしまう **「DDD（Deadline Driven Development＝締め切り駆動開発）」** を推奨し、登録してから内容を考え始めるくらいの勢いで取り組むのがよい
+- チェスのプロが5秒で打つ手と30分かけて打つ手は **86%一致する** という研究を引き合いに、最初の直感を信じて素早く形にすることの重要性を強調
+- 失敗を恐れずに数をこなし、**様々な種類のミスを経験することで上達していく** という心構えが、継続的な登壇の原動力になると語られた
+
+# LT3: goの標準パッケージregexpが先読みには対応していない話（[@taiyama1212](https://x.com/taiyama1212)）
+
+@[speakerdeck](30d9e719d8f54238a08aadec17928fea)
+
+- 業務中に正規表現 `8(?=2)` を使った際にエラーが発生したことをきっかけに、[Go](https://go.dev/) 標準ライブラリ [`regexp`](https://pkg.go.dev/regexp) が **正規表現の「先読み（lookahead）」に対応していない理由** を深掘りした発表
+- Go の `regexp` は Google が開発した **[RE2](https://github.com/google/re2)** というアルゴリズムの記法に従っており、[シンタックス仕様](https://github.com/google/re2/wiki/Syntax) として先読み・後読み（lookbehind）などの機能はサポートされていない
+- 先読みのアルゴリズムは、`a?` のようなオプション要素が N 文字あると `2^N` 通りの分解を試す必要があるなど、入力に対して **「指数関数的な実行時間を要する（処理が非常に遅くなるリスクがある）」**
+- RE2 は **「入力長に対して線形時間で動作すること」** を最優先の設計方針としており、最悪計算量が爆発する機能はあえて切り捨てることで、悪意のある入力による [ReDoS（正規表現 DoS）](https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS) のような攻撃を防いでいる
+- 機能の豊富さよりも **予測可能なパフォーマンス** を選ぶという RE2 の思想を、図解を交えてわかりやすく解説してくれた発表だった
+
+# 動画アーカイブ
+
+@[youtube](S8HKOyaOznU)
+
+各セクション開始タイムスタンプ:
+
+- [26:21](https://www.youtube.com/watch?v=S8HKOyaOznU&t=1581s) LT1: 続・Google Cloud を完全に理解した
+- [50:28](https://www.youtube.com/watch?v=S8HKOyaOznU&t=3028s) LT2: LT完全に理解した
+- [1:10:55](https://www.youtube.com/watch?v=S8HKOyaOznU&t=4255s) LT3: goの標準パッケージregexpが先読みには対応していない話
+
+# 関連リンク
+
+## 🌐ポータルサイト
+https://easy2.jp/
+
+## 🙌connpassコミュニティページ
+https://easy2.connpass.com/
+
+## 📺️『Easy Easy』YouTubeチャンネル
+https://www.youtube.com/@talk9929
+
+## 📝コミュニティ運営紹介記事
+https://zenn.dev/easy_easy/articles/3534caabc4f028
+
+https://zenn.dev/easy_easy/articles/89318e4d0acb4f


### PR DESCRIPTION
## Summary

- 2025年10月28日にオンライン開催した「完全に理解したTalk `#70`」のイベントレポートを追加
- LT1: 続・Google Cloud を完全に理解した（@ic_lifewood）
- LT2: LT完全に理解した（@cor_terisuke）
- LT3: goの標準パッケージregexpが先読みには対応していない話（@taiyama1212）

## Test plan

- [x] ローカルプレビュー（http://localhost:8001/articles/252d4d1a412ce4 ）で表示確認
- [x] Front Matter（topics 5個以内、type、publication_name）が規約準拠
- [x] docswell / speakerdeck / youtube 埋め込みが正しいID/URLになっている
- [x] 動画タイムスタンプが YouTube 説明欄と一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)