### PR TITLE
完全に理解したTalk #78 イベントレポートを追加

### DIFF
--- a/articles/8a847f6235ad4d.md
+++ b/articles/8a847f6235ad4d.md
@@ -1,0 +1,73 @@
+---
+title: "エンジニア達の「完全に理解した」Talk #78 イベントレポート"
+emoji: "📝"
+type: "idea" # tech: 技術記事 / idea: アイデア
+topics: [勉強会, イベント, android, opencode, ai]
+published: true
+publication_name: "easy_easy"
+---
+
+# エンジニア達の「完全に理解した」Talk #78
+
+2026年6月30日にオンライン開催した、完全に理解したTalkのスライド資料と概要まとめです。
+
+> 完全に理解した、それはまさに「分かった気になったくらい」の理解できたくらいのもの！「覚えたての知識」や「この知識なら自信出てきた！」みたいなものから「あれ、ちょっと怪しいかも？」となり始めた知識まで自分が話したい知識をなんでもゆるーく話をする会です！
+>
+> みんなにOUTPUTして、是非自分の実力を高めちゃいましょう！
+>
+> [完全に理解したTalk #78 - Easy Easy](https://easy2.connpass.com/event/395246/)
+
+# LT1: AI時代の新人教育 何を教えるべきか？（[@paseri_kurosawa](https://x.com/paseri_kurosawa)）
+
+@[docswell](https://www.docswell.com/s/3822049/5MQQ3G-2026-06-29-115014)
+
+- 生成AIがコードを書く時代になり「実装」の価値が低下する一方で、出力結果から選別・評価する **「判断」の重要性** が増しているにもかかわらず、新人教育が従来通りの「手を動かす前提」のままになっていると指摘
+- これからのAI時代には **「概念（構造や仕組み）」と「理由（なぜそれをやるのか）」を理解する基礎能力** が必須であり、単なる作業手順の習得だけでは通用しなくなると主張
+- その思考の土台作りとして、デジタルリテラシー標準である **「Di-Lite」（ITパスポートやFE、DS検定、G検定）** の資格取得を活用する教育アプローチを提案。
+- 非エンジニアはITパスポートから、エンジニアは基本情報技術者試験（FE）からスタートするなど、**職種に応じた実践的なステップ** も示された
+- 資格勉強を通じて概念と理由を体系的に押さえることで、AI時代に求められる判断力の基礎を養えると解説してくれた発表だった（※詳細は[Qiita記事](https://qiita.com/paseri_kurosawa/items/bf0279116c4a67bfbdd6)に記載）
+
+https://qiita.com/paseri_kurosawa/items/bf0279116c4a67bfbdd6
+
+# LT2: Androidアプリはマルチモジュールで作る時代ですよ（[@fkm](https://x.com/fkm)）
+
+https://docs.google.com/presentation/d/1km_Scsj7sl82aIyCmaHIFX2IsqfCY_JRlL-QcXOmyFY/edit?usp=sharing
+
+- Androidアプリ開発において、全体を1つのモジュール（APP）に詰め込むのではなく、機能やデータごとに分割する **「マルチモジュール」** での開発を推奨した発表
+- モジュールを分けることで **コードの再利用性が高まる** ほか、コード変更時に影響のあるモジュールのみがビルドされるため、**ビルド時間が大幅に短縮される** という大きなメリットを解説
+- さらに **Kotlin Multiplatform（KMP）** と組み合わせることで、そのまま **iOSアプリへの展開も可能** になることを紹介。
+- また、AI（Claudeなど）にコードを書かせる際にも、**影響範囲がモジュール単位に限定される** ため、毎回アプリ全体をビルドして確認する手間が省け、**AI開発とも非常に相性が良い** 点も強調
+- モジュール分割が単なる整理術にとどまらず、マルチプラットフォーム展開への布石にもなることが伝わる内容だった
+
+# LT3: OpenCode試してみた（[@mikene_koko](https://x.com/mikene_koko)）
+
+- ターミナルやIDEでのコーディングを支援するオープンソースのAIエージェント **「OpenCode」** を実際に試してみた報告
+- OpenCode は **エージェントとしての機能（指示の受け取り役）のみ** を持ち、実際の処理を行うAI（外部APIやローカルLLM）を自由に組み合わせて使用できるのが特徴
+- **無料で利用でき、利用制限などに合わせて背後のAIを簡単に切り替えられる** 点が便利である一方、AIからの処理結果を受け取り損ねて止まってしまう現象や、動作が若干遅い場合があるといった **使用感** も率直に共有
+- API経由（Geminiなど）とローカルLLM（Qwenなど）の双方で検証が行われ、**まずは無料のAPIを利用し、利用制限に引っかかったら別のAIやローカルに切り替える** という運用がお勧めとして紹介された発表だった
+
+# 動画アーカイブ
+
+@[youtube](J3D2xUH1T0g)
+
+各セクション開始タイムスタンプ:
+
+- [23:50](https://www.youtube.com/watch?v=J3D2xUH1T0g&t=1430s) LT1: AI時代の新人教育 何を教えるべきか？
+- [48:22](https://www.youtube.com/watch?v=J3D2xUH1T0g&t=2902s) LT2: Androidアプリはマルチモジュールで作る時代ですよ
+- [1:09:38](https://www.youtube.com/watch?v=J3D2xUH1T0g&t=4178s) LT3: OpenCode試してみた
+
+# 関連リンク
+
+## 🌐ポータルサイト
+https://easy2.jp/
+
+## 🙌connpassコミュニティページ
+https://easy2.connpass.com/
+
+## 📺️『Easy Easy』YouTubeチャンネル
+https://www.youtube.com/@talk9929
+
+## 📝コミュニティ運営紹介記事
+https://zenn.dev/easy_easy/articles/3534caabc4f028
+
+https://zenn.dev/easy_easy/articles/89318e4d0acb4f


### PR DESCRIPTION
## 概要

2026年6月30日にオンライン開催した「完全に理解したTalk [#78](https://easy2.connpass.com/event/395246/)」のイベントレポート記事を追加します。既存レポート（`#77`・`#76`）と同一の体裁で構成しました。

## 内容

- **LT1**: AI時代の新人教育 何を教えるべきか？（`@paseri_kurosawa`）— docswellスライド＋Qiita記事リンク
- **LT2**: Androidアプリはマルチモジュールで作る時代ですよ（`@fkm`）— Googleスライド
- **LT3**: OpenCode試してみた（`@mikene_koko`）
- 動画アーカイブ（YouTube）＋各LTのタイムスタンプ付きリンク
- 関連リンク（ポータル・connpass・YouTube・運営紹介記事）

各LTには一次情報を踏まえたレビュー追記（職種別ステップ、AI開発との親和性、推奨運用）を反映済み。`published: true` で公開設定。

## テストプラン

- [x] `npx zenn preview` でローカル表示確認
- [x] Front Matter（topics 5個以内・type・publication_name）の妥当性確認
- [x] スライド埋め込み・YouTube・タイムスタンプリンクの動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)