### PR TITLE
Talk #78レポート: 各LTに参考リンクを追記

### DIFF
--- a/articles/8a847f6235ad4d.md
+++ b/articles/8a847f6235ad4d.md
@@ -29,6 +29,10 @@ publication_name: "easy_easy"
 
 https://qiita.com/paseri_kurosawa/items/bf0279116c4a67bfbdd6
 
+## Di-Lite（デジタルリテラシー協議会）
+
+https://www.dilite.jp/
+
 # LT2: Androidアプリはマルチモジュールで作る時代ですよ（[@fkm](https://x.com/fkm)）
 
 https://docs.google.com/presentation/d/1km_Scsj7sl82aIyCmaHIFX2IsqfCY_JRlL-QcXOmyFY/edit?usp=sharing
@@ -39,12 +43,20 @@ https://docs.google.com/presentation/d/1km_Scsj7sl82aIyCmaHIFX2IsqfCY_JRlL-QcXOm
 - また、AI（Claudeなど）にコードを書かせる際にも、**影響範囲がモジュール単位に限定される** ため、毎回アプリ全体をビルドして確認する手間が省け、**AI開発とも非常に相性が良い** 点も強調
 - モジュール分割が単なる整理術にとどまらず、マルチプラットフォーム展開への布石にもなることが伝わる内容だった
 
+## Now in Android（マルチモジュール構成の公式サンプルアプリ）
+
+https://github.com/android/nowinandroid
+
 # LT3: OpenCode試してみた（[@mikene_koko](https://x.com/mikene_koko)）
 
 - ターミナルやIDEでのコーディングを支援するオープンソースのAIエージェント **「OpenCode」** を実際に試してみた報告
 - OpenCode は **エージェントとしての機能（指示の受け取り役）のみ** を持ち、実際の処理を行うAI（外部APIやローカルLLM）を自由に組み合わせて使用できるのが特徴
 - **無料で利用でき、利用制限などに合わせて背後のAIを簡単に切り替えられる** 点が便利である一方、AIからの処理結果を受け取り損ねて止まってしまう現象や、動作が若干遅い場合があるといった **使用感** も率直に共有
 - API経由（Geminiなど）とローカルLLM（Qwenなど）の双方で検証が行われ、**まずは無料のAPIを利用し、利用制限に引っかかったら別のAIやローカルに切り替える** という運用がお勧めとして紹介された発表だった
+
+## OpenCode（公式サイト）
+
+https://opencode.ai/
 
 # 動画アーカイブ
 


### PR DESCRIPTION
## 概要

マージ済みの「完全に理解したTalk `#78`」イベントレポートに対し、各LTの下部へ参考リンク（小見出し＋Zennカード展開用URL）を追記します。

## 追記内容

- **LT1** → `## Di-Lite（デジタルリテラシー協議会）`: https://www.dilite.jp/
- **LT2** → `## Now in Android（マルチモジュール構成の公式サンプルアプリ）`: https://github.com/android/nowinandroid
- **LT3** → `## OpenCode（公式サイト）`: https://opencode.ai/

見出しレベルは各LTセクション（`#`）直下の `##` に統一。

## テストプラン

- [x] 追記URLの疎通確認
- [x] 見出し階層（`#` → `##`）の整合確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)